### PR TITLE
Infra-tracker repository initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ inputs = {
 }
 ```
 
+### Initializing `infra-tracker`
+
+This repo is set up to provision new repositories via Terragrunt. To initialize the **infra-tracker** project repository, ensure it exists in `rstuhlmuller/github/terragrunt.hcl` under `inputs.github_repositories`, then run:
+
+```bash
+cd rstuhlmuller/github
+terragrunt plan
+terragrunt apply
+```
+
 ## Development Environment 🧰
 
 This project includes a devcontainer configuration with all necessary tools pre-installed:

--- a/rstuhlmuller/github/terragrunt.hcl
+++ b/rstuhlmuller/github/terragrunt.hcl
@@ -34,6 +34,11 @@ inputs = {
       description = "Kubernetes homelab deployment"
       visibility  = "public"
     }
+    infra-tracker = {
+      description        = "Vibe coding project for tracking infrastructure changes"
+      visibility         = "public"
+      gitignore_template = "Python"
+    }
     terragrunt-catalog = {
       description = "Terragrunt configuration catalog for terragrunt stacks"
       visibility  = "public"


### PR DESCRIPTION
Add `infra-tracker` repository definition and provisioning instructions to initialize the new project.

---
<a href="https://cursor.com/background-agent?bcId=bc-cad01115-9210-490b-be9b-ec848022ca76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cad01115-9210-490b-be9b-ec848022ca76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

