### PR TITLE
fix: use ssm github token for deploy

### DIFF
--- a/Stuhlmuller/repositories/.terraform.lock.hcl
+++ b/Stuhlmuller/repositories/.terraform.lock.hcl
@@ -1,6 +1,43 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.47.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:48shBmRvgQamqp4R0I21LR9UmQ9Sgi9l9ETpMHecFzU=",
+    "h1:5iXhisFZ5axHP9KCoLTdejzA7w3CWuXUyhFmon8F2gk=",
+    "h1:8Q4oFdOJb5v60T+U3cgJK9kCvukxY7XcXEHh563WKJo=",
+    "h1:A08ZGnJaZ2vcIRTgkTe3CPK94gP3ko2VDDu3ActwqLY=",
+    "h1:B/G4brODNHzxE9wtam7vsIdlmo0jjhgq1/hoF3wONAk=",
+    "h1:XZcF3rd34MNtmuUrV5wWnon1ZhBWHEfHloVFstGE+Cg=",
+    "h1:ZwEAqf8C6jRRrht4OLuCC09G6DIuVi7ihYraoBAmnHU=",
+    "h1:aXixj6rhGPZjtzvApjS30lQfiFzp8mBFiNPzu5z02Fo=",
+    "h1:bGohxq41e1rgM2nV8TPjm5lRJHyg632dklSCVCnTFoQ=",
+    "h1:cFa+lfjaFN77rYi7Xa7c2qyzprBh9aKEQM5s3KdkdOA=",
+    "h1:e7JTxPYaqlFVPkXuK9JgXWfOhTEekpHQI7dKx+Sk4Sk=",
+    "h1:izQ62W2MMo1VZ8VE2N2R++xdezTIyc/3thXgFoFVh/g=",
+    "h1:mVCRTbQfogYGmKnS+4FZCUB8Osiu4Uvh9fxpsF5gZlA=",
+    "h1:oUB8PFTvKe1UfQvoyzeDz5jNbM6FqlGRWoINGm3GkRM=",
+    "h1:oo2v8/ePwW1Cs3IhA96w1steLo7l5ZjnmKxg2wWasJA=",
+    "zh:20fe2486489236dd558992efca2b40be286b31e750691c9bcf0328fa3bd98ee8",
+    "zh:23f283ceb7422e9f00a9363d6e5d82553d50749ffa85402239c88131be722f35",
+    "zh:2ae37c746d5dfcb8df0a8ef325621c3a7a4393daa66b077b83a79b817a67ef91",
+    "zh:3447c8567d2978a554ab6771a4533cc7af682bc869533091b87d2c8506c2ac16",
+    "zh:523a0ba927037fa3380f9dafdf54f6703c0de4db3b645abfe18a5bdd6dd94f2a",
+    "zh:6fc3ef5ee28d13dc0aa07f442bebd5d2b829d9900c7bbddaa8533770ead68d43",
+    "zh:72335055bf547f21aa7e64c1e79d1461d62c497e5f887491e7bc1483516749aa",
+    "zh:7c98217a75edb2282979d39daad72321b10e5b90e420a2c70332d8afb17093e5",
+    "zh:8a5ca65c89f389e8b5b648d428f28acf241563e9d0e893baeaef13604f94038e",
+    "zh:8eeb19cb3abb45a9831bbd34a24278104235848aa949b267ac0d1b014f5da30b",
+    "zh:a43a03bc9306dc0dd3f1f843ca1c291f24b5d41bd7485b61a83cd99184de73d8",
+    "zh:a54032cb98ad9bf43eb99408fd0896e091188a5354f44f7dd4ef258560dd40e5",
+    "zh:caba3a1ee1f9d99fff8ccb9f99e9e3c3ed554f2912c8257272f9d0b62b806d6a",
+    "zh:e4018d10ff9eac971213a08963f54eaa54e4d872cf78c773c0da9b93c9d739bb",
+    "zh:fa3a6eb20984e569e0e95cad63a5ebc05320742504a8062de764715edfdd1f8a",
+  ]
+}
+
 provider "registry.opentofu.org/integrations/github" {
   version     = "6.12.1"
   constraints = "~> 6.12.0"

--- a/Stuhlmuller/repositories/terragrunt.hcl
+++ b/Stuhlmuller/repositories/terragrunt.hcl
@@ -1,6 +1,5 @@
 locals {
-  org_vars     = read_terragrunt_config(find_in_parent_folders("org.hcl")).locals
-  github_token = trimspace(get_env("GITHUB_TOKEN", get_env("GH_TOKEN", "")))
+  org_vars = read_terragrunt_config(find_in_parent_folders("org.hcl")).locals
   public_repository_config = {
     visibility                = "public"
     delete_branch_on_merge    = true
@@ -26,8 +25,17 @@ generate "provider" {
   path      = "github-provider.tf"
   if_exists = "overwrite_terragrunt"
   contents  = <<-EOF
+  provider "aws" {
+    region = "us-east-1"
+  }
+
+  data "aws_ssm_parameter" "personal_access_token" {
+    name = "/github-iac/personal_access_token"
+  }
+
   provider "github" {
     owner = "${local.org_vars.organization}"
+    token = data.aws_ssm_parameter.personal_access_token.value
   }
   EOF
 }

--- a/Stuhlmuller/repositories/terragrunt.hcl
+++ b/Stuhlmuller/repositories/terragrunt.hcl
@@ -26,7 +26,7 @@ generate "provider" {
   if_exists = "overwrite_terragrunt"
   contents  = <<-EOF
   provider "aws" {
-    region = "us-east-1"
+    region = "us-west-2"
   }
 
   data "aws_ssm_parameter" "personal_access_token" {

--- a/modules/github_repositories/init.tf
+++ b/modules/github_repositories/init.tf
@@ -1,5 +1,9 @@
 terraform {
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
     github = {
       source  = "integrations/github"
       version = "~> 6.12.0"


### PR DESCRIPTION
## Summary
- Restore the GitHub provider token from AWS SSM Parameter Store.
- Read the token from `us-west-2`, matching the workflow's assumed-role region.
- Add the AWS provider requirement needed by the generated SSM data source.
- Refresh the repositories lockfile with the AWS provider.

## Context
The deploy run after PR #67 reached `tofu apply`, then failed with `403 Resource not accessible by integration` while patching repositories and creating the organization ruleset. The provider was falling back to the workflow `GITHUB_TOKEN`; the repo README documents the intended `/github-iac/personal_access_token` SSM parameter.

The first version of this PR proved the SSM provider path works but `us-east-1` did not contain that parameter, so this points the generated provider at `us-west-2`.

## Validation
- `terragrunt hcl fmt --check --diff`
- `terragrunt init -backend=false -upgrade` in `Stuhlmuller/repositories`