### PR TITLE
feat: enforce policy-bot on public repos

### DIFF
--- a/Stuhlmuller/org.hcl
+++ b/Stuhlmuller/org.hcl
@@ -43,8 +43,14 @@ locals {
             include = ["~DEFAULT_BRANCH"]
             exclude = []
           }
-          repository_name = {
-            include = ["~ALL"]
+          repository_property = {
+            include = [
+              {
+                name            = "visibility"
+                property_values = ["public"]
+                source          = "system"
+              }
+            ]
             exclude = []
           }
         }

--- a/modules/github_repositories/README.md
+++ b/modules/github_repositories/README.md
@@ -2,17 +2,18 @@
 
 This module reconciles GitHub repositories for an organization from a single list of repository configurations plus an organization-wide default configuration.
 
-It does three things:
+It does five things:
 
 1. Reads all repositories in the organization with `data.github_repositories`.
 2. Merges explicit `repositories` entries with `default_repository_config`.
 3. Imports discovered repositories into OpenTofu state and manages them with the merged configuration.
 4. Applies per-repository rulesets derived from `default_repository_ruleset_config` and each repository's `ruleset` list.
+5. Applies organization-level rulesets from `organization_rulesets`.
 
 ## Requirements
 
 - OpenTofu with support for iterable `import` blocks.
-- `integrations/github` provider `6.6.x`.
+- `integrations/github` provider `6.12.x`.
 
 ## Inputs
 
@@ -20,6 +21,7 @@ It does three things:
 - `repositories`: Map of repository-specific overrides keyed by repository name.
 - `default_repository_config`: Baseline settings used for all repositories and applied automatically to discovered repositories that are not explicitly configured.
 - `default_repository_ruleset_config`: Baseline ruleset settings merged into every ruleset entry.
+- `organization_rulesets`: Organization-level rulesets to apply, including repository-property targeting for dynamic scopes such as public repositories.
 - `results_per_page`: Page size for the GitHub repository search data source.
 
 ## Example

--- a/modules/github_repositories/main.tf
+++ b/modules/github_repositories/main.tf
@@ -247,6 +247,14 @@ resource "github_organization_ruleset" "this" {
           exclude = try(repository_name.value.exclude, [])
         }
       }
+
+      dynamic "repository_property" {
+        for_each = try(conditions.value.repository_property, null) == null ? [] : [conditions.value.repository_property]
+        content {
+          include = try(repository_property.value.include, [])
+          exclude = try(repository_property.value.exclude, [])
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

This change narrows the organization-level Policy Bot ruleset so it enforces `policy-bot: main` only on public repositories in the Stuhlmuller organization.

The previous org ruleset targeted `repository_name.include = ["~ALL"]`, which applied the Policy Bot required status check to every repository matched by the organization ruleset. That made the desired public-repository policy broader than intended and risked requiring the shared `.github` Policy Bot workflow on private repositories as well.

The fix switches the ruleset condition to provider-native repository property targeting. The ruleset now selects repositories where the system property `visibility` is `public`, while keeping the existing default-branch scope and required `policy-bot: main` check from integration `3280987`.

The module also now passes `repository_property` conditions through to `github_organization_ruleset`, and its README documents organization-level ruleset support and the current GitHub provider generation.

## Validation

- `tofu fmt -recursive -check`
- `terragrunt hcl format --check`
- `terragrunt --log-disable --working-dir Stuhlmuller/repositories init -backend=false -no-color`
- `terragrunt --log-disable --working-dir Stuhlmuller/repositories validate -no-color`
- `git diff --check`
- pre-commit hooks during commit: OpenTofu fmt, Terragrunt hcl fmt, codespell, Checkov, Checkov Secrets, and terraform-docs

Full backend validation was attempted but the local AWS SSO token is expired, so backend-disabled validation was used to verify provider schema and configuration syntax without remote state access.
