### PR TITLE
fix: enforce policy-bot per repository

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,9 @@ jobs:
 
       - name: Terragrunt Deploy
         uses: gruntwork-io/terragrunt-action@4ed5b7344c80315e5357f28f36159fc980bc2d5a # v3
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           tg_dir: ${{ env.working_dir }}
           tg_command: 'run --all --non-interactive -- apply'

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -56,9 +56,6 @@ jobs:
 
       - name: Terragrunt Plan
         uses: gruntwork-io/terragrunt-action@4ed5b7344c80315e5357f28f36159fc980bc2d5a # v3
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           tg_dir: ${{ env.working_dir }}
           tg_command: 'run --all --non-interactive --summary-per-unit --log-format bare -- plan'

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -56,6 +56,9 @@ jobs:
 
       - name: Terragrunt Plan
         uses: gruntwork-io/terragrunt-action@4ed5b7344c80315e5357f28f36159fc980bc2d5a # v3
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           tg_dir: ${{ env.working_dir }}
           tg_command: 'run --all --non-interactive --summary-per-unit --log-format bare -- plan'

--- a/Stuhlmuller/org.hcl
+++ b/Stuhlmuller/org.hcl
@@ -24,6 +24,16 @@ locals {
     creation                   = true
     update                     = false
     deletion                   = true
+    required_status_checks = [
+      {
+        required_check = [
+          {
+            context        = "policy-bot: main"
+            integration_id = 3280987
+          }
+        ]
+      }
+    ]
     bypass_actors = [
       {
         actor_id    = 2145192
@@ -32,39 +42,5 @@ locals {
       }
     ]
   }
-  organization_rulesets = [
-    {
-      name        = "policy-bot"
-      target      = "branch"
-      enforcement = "active"
-      conditions = [
-        {
-          ref_name = {
-            include = ["~DEFAULT_BRANCH"]
-            exclude = []
-          }
-          repository_property = {
-            include = [
-              {
-                name            = "visibility"
-                property_values = ["public"]
-                source          = "system"
-              }
-            ]
-            exclude = []
-          }
-        }
-      ]
-      required_status_checks = [
-        {
-          required_check = [
-            {
-              context        = "policy-bot: main"
-              integration_id = 3280987
-            }
-          ]
-        }
-      ]
-    }
-  ]
+  organization_rulesets = []
 }

--- a/Stuhlmuller/repositories/terragrunt.hcl
+++ b/Stuhlmuller/repositories/terragrunt.hcl
@@ -59,6 +59,9 @@ inputs = {
     "homelab" = {
       visibility = "public"
     }
+    "hivemind" = {
+      visibility = "public"
+    }
     "octobot-deploy" = {
       archived = true
     }


### PR DESCRIPTION
## Summary

This changes Policy Bot enforcement from an organization ruleset to the existing per-repository `main` rulesets for public repositories, and fixes the trusted deploy workflow so Terraform can apply those repository ruleset updates.

The org-level ruleset approach was not the right enforcement shape for this setup. The desired check needs to land on each public repository's repository ruleset instead. The shared `.github` Policy Bot policy still supplies the approval logic, but GitHub now receives the required `policy-bot: main` status check through each repo's `github_repository_ruleset.this["<repo>.main"]`.

This removes the active `organization_rulesets` input for Stuhlmuller and adds the `policy-bot: main` required status check to `default_repository_ruleset_config`. Existing public repositories already inherit the `main` ruleset, so apply will update those individual repo rulesets instead of creating an org ruleset. `hivemind` is also explicitly marked public in the config so the current public repository set is covered.

The deploy workflow also exports the GitHub App installation token as `GITHUB_TOKEN` and `GH_TOKEN` only in the trusted `Terragrunt Deploy` step. That gives the GitHub provider credentials for apply without exposing the high-privilege token to pull-request-controlled Terragrunt plans.

## Validation

- `tofu fmt -recursive -check`
- `terragrunt hcl format --check`
- `terragrunt --log-disable --working-dir Stuhlmuller/repositories validate -no-color`
- `git diff --check`
- commit hooks: YAML validation, trailing whitespace, EOF, large-file check, Terragrunt hcl fmt, codespell, Checkov Secrets

Manual deploy run `27053419220` showed the previous deploy auth failure: the backend and provider initialized, then GitHub mutations failed with `401 Requires authentication`. After this merges, rerun `Terragrunt Deploy` from `main` to apply the per-repository ruleset updates.
