### PR TITLE
ci: require homelab lint check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,9 @@ jobs:
 
       - name: Terragrunt Deploy
         uses: gruntwork-io/terragrunt-action@4ed5b7344c80315e5357f28f36159fc980bc2d5a # v3
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           tg_dir: ${{ env.working_dir }}
           tg_command: 'run --all --non-interactive -- apply'

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -56,6 +56,9 @@ jobs:
 
       - name: Terragrunt Plan
         uses: gruntwork-io/terragrunt-action@4ed5b7344c80315e5357f28f36159fc980bc2d5a # v3
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           tg_dir: ${{ env.working_dir }}
           tg_command: 'run --all --non-interactive --summary-per-unit --log-format bare -- plan'

--- a/Stuhlmuller/repositories/terragrunt.hcl
+++ b/Stuhlmuller/repositories/terragrunt.hcl
@@ -58,6 +58,21 @@ inputs = {
     }
     "homelab" = {
       visibility = "public"
+      ruleset = [
+        {
+          name = "main"
+          required_status_checks = [
+            {
+              required_check = [
+                {
+                  context        = "Lint"
+                  integration_id = 15368
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
     "octobot-deploy" = {
       archived = true

--- a/modules/github_repositories/variables.tf
+++ b/modules/github_repositories/variables.tf
@@ -10,38 +10,13 @@ variable "organization" {
 
 variable "repositories" {
   description = "Repository-specific overrides keyed by repository name. Existing repositories that are not listed here inherit default_repository_config."
-  type = map(object({
-    description                = optional(string)
-    visibility                 = optional(string)
-    homepage_url               = optional(string)
-    gitignore_template         = optional(string)
-    default_branch             = optional(string)
-    rename_default_branch      = optional(bool)
-    require_code_owner_reviews = optional(bool)
-    is_template                = optional(bool)
-    repository_template = optional(object({
-      owner                = string
-      repository           = string
-      include_all_branches = optional(bool)
-    }))
-    ruleset                     = optional(list(any))
-    delete_branch_on_merge      = optional(bool)
-    has_downloads               = optional(bool)
-    has_issues                  = optional(bool)
-    has_projects                = optional(bool)
-    has_wiki                    = optional(bool)
-    allow_update_branch         = optional(bool)
-    allow_auto_merge            = optional(bool)
-    allow_merge_commit          = optional(bool)
-    allow_squash_merge          = optional(bool)
-    squash_merge_commit_message = optional(string)
-    squash_merge_commit_title   = optional(string)
-    allow_rebase_merge          = optional(bool)
-    archived                    = optional(bool)
-    auto_init                   = optional(bool)
-    vulnerability_alerts        = optional(bool)
-  }))
-  default = {}
+  type        = any
+  default     = {}
+
+  validation {
+    condition     = can(keys(var.repositories))
+    error_message = "repositories must be an object or map keyed by repository name."
+  }
 }
 
 variable "default_repository_config" {


### PR DESCRIPTION
## Summary

Require the homelab repository's `Lint` GitHub Actions check before changes can merge to the default branch, and repair the GitHub IaC module so Terragrunt can plan repository-specific ruleset overrides that have richer nested status-check configuration.

## Issue

The homelab repository has a live `Lint` workflow, but the GitHub IaC ruleset for homelab did not require that check to pass. That left pull requests able to satisfy branch rules without the lint gate being enforced by GitHub rulesets.

After adding the homelab-specific ruleset override, the Terragrunt Plan workflow failed before it could produce a valid plan. OpenTofu rejected `TF_VAR_repositories` because most repository overrides were small objects such as `{ visibility = "public" }`, while the homelab override included a nested `ruleset.required_status_checks` object. The module input type required a homogeneous `map(object(...))`, so the mixed override shapes could not be converted.

## Cause And Effect

Homelab inherits the shared public-repository `main` ruleset from this IaC repo, and the repository-specific homelab override only set visibility. Because the ruleset did not include a homelab-specific required status check, the `Lint` workflow could run without being a merge requirement.

The module already merges each repository override with `default_repository_config` before resources consume the values. The overly strict input type duplicated that shape too early, at the variable boundary, and prevented valid sparse overrides from reaching the existing normalization logic.

## Fix

Add a homelab-only `main` ruleset override that requires the `Lint` check from the GitHub Actions app. The live check-run context is `Lint`, and the GitHub Actions app integration id is `15368`.

Expose the generated GitHub App token to Terragrunt as `GITHUB_TOKEN` and `GH_TOKEN` so the GitHub provider can authenticate during plan and deploy runs. This fixes the deploy-side `401 Requires authentication` failures from GitHub repository and ruleset updates.

Relax the `repositories` input type to `any` with a validation guard that still requires an object or map keyed by repository name. This lets sparse per-repository overrides keep their natural shape while preserving the module's existing merge-with-defaults behavior.

## Validation

- Verified the live homelab workflow list includes active `.github/workflows/lint.yml` named `Lint`.
- Verified recent homelab check-runs report the required context as `Lint` with GitHub Actions app id `15368`.
- Ran `tofu fmt -check -diff -recursive`.
- Ran `terragrunt hcl fmt --check --diff`.
- Ran `git diff --check`.
- Ran backend-disabled `terragrunt run --non-interactive -- init -backend=false`; provider initialization succeeded when registry network access was available.
- Ran a focused OpenTofu variable-conversion smoke test with the same mixed `TF_VAR_repositories` payload that failed in Actions.
- Verified PR #77's Terragrunt Plan rerun succeeded on commit `7267b9b`.
- Verified the latest manual Terragrunt Deploy run on the auth-fix branch succeeded.
- Commit hooks passed, including OpenTofu formatting, Terragrunt HCL formatting, codespell, Checkov, Checkov Secrets, and terraform-docs.
