### PR TITLE
feat: require homelab merge protections

### DIFF
--- a/Stuhlmuller/repositories/terragrunt.hcl
+++ b/Stuhlmuller/repositories/terragrunt.hcl
@@ -60,7 +60,13 @@ inputs = {
       visibility = "public"
       ruleset = [
         {
-          name = "main"
+          name                   = "main"
+          require_signed_commits = true
+          pull_requests = [
+            {
+              required_review_thread_resolution = true
+            }
+          ]
           required_status_checks = [
             {
               required_check = [

--- a/modules/github_repositories/main.tf
+++ b/modules/github_repositories/main.tf
@@ -192,8 +192,9 @@ resource "github_repository_ruleset" "this" {
     dynamic "pull_request" {
       for_each = try(each.value.pull_requests, [])
       content {
-        required_approving_review_count = try(pull_request.value.required_approving_review_count, null)
-        require_code_owner_review       = try(pull_request.value.require_code_owner_reviews, each.value.require_code_owner_reviews)
+        required_approving_review_count   = try(pull_request.value.required_approving_review_count, null)
+        require_code_owner_review         = try(pull_request.value.require_code_owner_reviews, each.value.require_code_owner_reviews)
+        required_review_thread_resolution = try(pull_request.value.required_review_thread_resolution, null)
       }
     }
 


### PR DESCRIPTION
## Summary

This PR tightens the managed GitHub ruleset for `Stuhlmuller/homelab` so the repository now requires signed commits and resolved PR review conversations before changes can merge to the default branch.

## Issue

The homelab repository is operated through PR-based GitOps changes, but its repository-specific ruleset was only inheriting the organization defaults. Those defaults currently keep signed commits disabled and did not expose the GitHub ruleset option that blocks merges while review conversations remain unresolved.

For users and agents working in the homelab repo, that meant a PR could merge without a signed commit requirement and with unresolved code-review threads still open. That leaves useful review signals easier to bypass and makes merge readiness less explicit.

## Root Cause

The GitHub repository module already had a `pull_request` ruleset block, but it did not pass through the provider's `required_review_thread_resolution` argument. The `homelab` repository also did not override the default `require_signed_commits = false` setting from the shared `Stuhlmuller` org config.

## Fix

The module now accepts `required_review_thread_resolution` inside repository ruleset `pull_requests` entries and passes it through to `github_repository_ruleset`.

The `Stuhlmuller/homelab` repository entry now overrides its `main` ruleset to enable `require_signed_commits = true` and adds a pull request rule requiring review thread resolution.

## Validation

- `tofu fmt -check -recursive`
- `terragrunt hcl format --check`
- `git diff --check`
- `terragrunt run -- init -backend=false`
- `terragrunt run -- validate`
- Commit hooks during signed commit:
  - trailing whitespace
  - end-of-file check
  - large-file check
  - OpenTofu fmt
  - Terragrunt hcl fmt
  - codespell
  - Checkov
  - Checkov Secrets
  - terraform-docs

Full backend-backed validation was not available because the local AWS SSO session returned `InvalidGrantException`, so validation was completed with backend initialization disabled.
