### PR TITLE
feat: require policy-bot on homelab

### DIFF
--- a/Stuhlmuller/repositories/terragrunt.hcl
+++ b/Stuhlmuller/repositories/terragrunt.hcl
@@ -67,6 +67,10 @@ inputs = {
                 {
                   context        = "Lint"
                   integration_id = 15368
+                },
+                {
+                  context        = "policy-bot: main"
+                  integration_id = 3280987
                 }
               ]
             }


### PR DESCRIPTION
## Summary

This PR updates the GitHub IaC desired state so the `Stuhlmuller/homelab` repository requires the `policy-bot: main` status check on its main-branch ruleset.

The homelab repository already had a repo-specific ruleset override to require the `Lint` check. Because that override replaces the default required status check list, homelab did not inherit the default `policy-bot: main` requirement even though other public repositories do.

The user-facing effect is that homelab pull requests could be mergeable through the repository ruleset without Policy Bot being part of the required status gate. That weakens the intended shared `.github` policy model for the repo where those policies matter most.

The fix keeps the existing `Lint` requirement and adds `policy-bot: main` with the known GitHub App integration id `3280987` to the same homelab ruleset override. This preserves the existing lint gate while making Policy Bot required on homelab's default branch.

## Validation

- `tofu fmt -recursive -check`
- `terragrunt hcl format --check`
- `terragrunt --log-disable --working-dir Stuhlmuller/repositories init -backend=false -no-color`
- `terragrunt --log-disable --working-dir Stuhlmuller/repositories validate -no-color`
- Commit hooks during `git commit -S`
- `git log --show-signature -1 --format=fuller`
